### PR TITLE
Add doc build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 This repository hosts notes for learning and using Raspberry Pi 5. All documentation has moved to the [docs/](docs/) directory.
 
+## Documentation
+
+Use the provided `Makefile` targets to build and preview the documentation:
+
+- `make docs` &mdash; build the static site into the `site/` directory.
+- `make serve` &mdash; start a local server so you can preview the docs.
+


### PR DESCRIPTION
## Summary
- show how to build docs and serve them via Makefile

## Testing
- `make docs` *(fails: mkdocs not found)*
- `make serve` *(fails: mkdocs not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b6c171ba08331be6f8301d4ef603a