### PR TITLE
Add docs build workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,25 @@
+name: Build Docs
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install mkdocs
+      - name: Build documentation
+        run: make docs
+      - name: Upload site
+        uses: actions/upload-artifact@v3
+        with:
+          name: site
+          path: site/


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build docs on each push or PR

## Testing
- `make docs` *(fails: mkdocs not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6870b7ae3c908331b01ee34c5732f5bb