### PR TITLE
Add repo links for sensor tools

### DIFF
--- a/docs/nrf24l01.md
+++ b/docs/nrf24l01.md
@@ -63,4 +63,6 @@ while True:
 
 另一台树莓派或 Arduino 上配置相同地址即可接收数据。更多高级用法请参考库文档。
 
+更多脚本与演示可在 [pi5-nrf24l01-tools](https://github.com/SwartzMss/pi5-nrf24l01-tools) 仓库中找到。
+
 

--- a/docs/oled.md
+++ b/docs/oled.md
@@ -41,3 +41,5 @@ with canvas(device) as draw:
 
 运行脚本即可在 1.3 寸屏幕上看到文字。`luma.oled` 还支持绘制
 图形、显示图片等功能，可根据需要进一步探索。
+
+完整示例脚本可在 [pi5-oled-i2c-tools](https://github.com/SwartzMss/pi5-oled-i2c-tools) 获取。

--- a/docs/sensors.md
+++ b/docs/sensors.md
@@ -140,6 +140,8 @@ except KeyboardInterrupt:
 
 这种方法只能粗略地区分明暗，但足以在没有模数转换器的情况下测试光敏电阻。
 
+更多脚本与说明请参考 [pi5-photoresistor-tools](https://github.com/SwartzMss/pi5-photoresistor-tools)。
+
 ## 声音传感器 (KY-038)
 
 KY-038 或 KY-037 等声音传感器可侦测环境中的噪音强度，通常同时提供模拟 (A0) 与数字 (D0) 输出。如果需要量化声音幅度，可将 A0 接至 MCP3008 等 ADC 模块。
@@ -164,4 +166,6 @@ while True:
 ```
 
 上述示例在声音达到阈值时打印提示，可通过 `threshold` 属性调整灵敏度。
+
+更多脚本与说明请参考 [pi5-soundsensor-tools](https://github.com/SwartzMss/pi5-soundsensor-tools)。
 


### PR DESCRIPTION
## Summary
- reference pi5-nrf24l01-tools in the nRF24L01 guide
- link to pi5-oled-i2c-tools from the OLED doc
- add pi5-photoresistor-tools and pi5-soundsensor-tools links to sensors doc

## Testing
- `make docs` *(fails: mkdocs not found)*

------
https://chatgpt.com/codex/tasks/task_e_68773f8e236483319f5fc11ca48ce2c2