### PR TITLE
Add buzzer docs

### DIFF
--- a/docs/buzzer.md
+++ b/docs/buzzer.md
@@ -1,0 +1,58 @@
+# 蜂鸣器（Buzzer）使用
+
+蜂鸣器是常见的声音输出设备，分为主动和被动两种。主动蜂鸣器只需给定高低电平即可响，
+被动蜂鸣器则需要以 PWM 方式产生不同频率的方波才能发声。
+
+## 硬件连接
+
+- VCC 接 3.3V（主动蜂鸣器）或经晶体管接 5V
+- GND 接 GND
+- 控制脚接任意 GPIO，以下示例假设使用 GPIO18
+
+## gpiozero 示例
+
+```python
+from gpiozero import Buzzer
+from time import sleep
+
+bz = Buzzer(18)
+
+bz.on()
+sleep(1)
+bz.off()
+
+# 循环蜂鸣
+for _ in range(3):
+    bz.beep(on_time=0.2, off_time=0.2, n=5, background=False)
+```
+
+## RPi.GPIO PWM 示例（适合被动蜂鸣器）
+
+```python
+import RPi.GPIO as GPIO
+import time
+
+GPIO.setmode(GPIO.BCM)
+BUZZ_PIN = 18
+GPIO.setup(BUZZ_PIN, GPIO.OUT)
+
+pwm = GPIO.PWM(BUZZ_PIN, 1000)  # 1 kHz
+pwm.start(50)  # 50% 占空比
+
+time.sleep(1)
+pwm.ChangeFrequency(2000)
+time.sleep(1)
+
+pwm.stop()
+GPIO.cleanup()
+```
+
+更多脚本与说明可参考外部仓库 [pi5-buzz-tools](https://github.com/SwartzMss/pi5-buzz-tools)。
+
+### 使用仓库示例
+
+仓库中提供的 `main.py` 可以让蜂鸣器按照设定次数和间隔鸣叫：
+
+```bash
+python3 main.py --times 3 --interval 0.5 --pin 16
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@
 - [蓝牙配置与数据交换](./bluetooth.md)
 - [nRF24L01 无线模块](./nrf24l01.md)
 - [电机基础](./motors.md)
+- [蜂鸣器使用](./buzzer.md)
 - 硬件监控命令
 - 学习过程中的常用技巧
 - [ESP32-CAM 模块使用](./esp32cam.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ nav:
   - GPIO 操作指南: gpio.md
   - 蓝牙配置与数据交换: bluetooth.md
   - 传感器: sensors.md
+  - 蜂鸣器: buzzer.md
   - 电机基础: motors.md
   - nRF24L01 无线模块: nrf24l01.md
   - SH1106 OLED 屏幕: oled.md


### PR DESCRIPTION
## Summary
- add buzzer usage guide
- link buzzer page in index
- add nav entry
- expand buzzer section with repo example

## Testing
- `make docs` *(fails: mkdocs missing)*

------
https://chatgpt.com/codex/tasks/task_e_6878fce2a7a4833190504529f63d3144