### PR TITLE
Add USB sound card guide

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@
 - [nRF24L01 无线模块](./nrf24l01.md)
 - [电机基础](./motors.md)
 - [蜂鸣器使用](./buzzer.md)
+- [USB 外置声卡](./usb-soundcard.md)
 - 硬件监控命令
 - 学习过程中的常用技巧
 - [ESP32-CAM 模块使用](./esp32cam.md)

--- a/docs/usb-soundcard.md
+++ b/docs/usb-soundcard.md
@@ -1,0 +1,54 @@
+# USB 外置声卡使用
+
+本文档介绍在 Raspberry Pi 5 上使用常见 USB 声卡的方法。
+
+## 1. 检查设备是否识别
+
+1. 将声卡插入 USB 接口。
+2. 运行 `lsusb` 和 `aplay -l` 查看系统是否识别到新的音频设备。
+
+```bash
+lsusb        # 查看 USB 设备列表
+aplay -l     # 列出所有声卡
+```
+
+如果输出中出现诸如 `USB Audio` 的条目，表示设备已被系统识别。
+
+## 2. 安装 ALSA 工具
+
+若系统尚未安装 `alsa-utils`，可以执行：
+
+```bash
+sudo apt update
+sudo apt install -y alsa-utils
+```
+
+安装完成后，可使用 `alsamixer` 查看并调整音量。
+
+## 3. 设置为默认音频输出
+
+1. 打开或创建 `~/.asoundrc` 文件：
+
+```bash
+nano ~/.asoundrc
+```
+
+2. 将以下内容写入文件，将卡号替换为 `aplay -l` 输出中的 USB 声卡编号：
+
+```plain
+defaults.ctl.card 1
+defaults.pcm.card 1
+```
+
+3. 保存后重新登录或重启，让设置生效。
+
+## 4. 测试播放
+
+执行以下命令播放测试声音：
+
+```bash
+speaker-test -c2 -twav
+```
+
+若能听到左右声道的测试音，即说明 USB 声卡工作正常。
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
   - 树莓派专用命令: commands.md
   - GPIO 操作指南: gpio.md
   - 蓝牙配置与数据交换: bluetooth.md
+  - USB 外置声卡: usb-soundcard.md
   - 传感器: sensors.md
   - 脚本系统服务: service.md
   - 蜂鸣器: buzzer.md


### PR DESCRIPTION
## Summary
- add instructions for using a USB audio interface
- reference the guide from README navigation
- update documentation nav

## Testing
- `make docs` *(fails: mkdocs not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687f2a95bfe48331ac48d528491f3cc4