### PR TITLE
Add MG90S servo docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@
 - [蓝牙配置与数据交换](./bluetooth.md)
 - [nRF24L01 无线模块](./nrf24l01.md)
 - [电机基础](./motors.md)
+- [MG90S 舵机](./servo.md)
 - [蜂鸣器使用](./buzzer.md)
 - [USB 外置声卡](./usb-soundcard.md)
 - 硬件监控命令

--- a/docs/servo.md
+++ b/docs/servo.md
@@ -1,0 +1,70 @@
+# MG90S 舵机使用
+
+MG90S 是常见的 9 克金属齿轮舵机，适合在树莓派上进行角度控制实验。本文件介绍基本接线和 Python 控制示例。
+
+## 硬件连接
+
+| MG90S 引脚 | Raspberry Pi 引脚 |
+|------------|-------------------|
+| 棕线 (GND) | GND (任意针脚)    |
+| 红线 (VCC) | 5V (Pin 2 或 4)   |
+| 橙线 (信号) | GPIO18 (Pin 12)   |
+
+建议单独给舵机供电，并与树莓派共地，避免电流过大造成系统不稳定。
+
+## 安装所需库
+
+```bash
+sudo apt update
+sudo apt install python3-gpiozero
+```
+
+如需更高精度的 PWM，可以改用 `pigpio`：
+
+```bash
+sudo apt install pigpio python3-pigpio
+sudo systemctl start pigpiod
+```
+
+## gpiozero 示例
+
+```python
+from gpiozero import Servo
+from time import sleep
+
+servo = Servo(18)
+
+while True:
+    servo.mid()  # 90°
+    sleep(1)
+    servo.min()  # 0° 左右
+    sleep(1)
+    servo.max()  # 180° 左右
+    sleep(1)
+```
+
+## RPi.GPIO PWM 示例
+
+```python
+import RPi.GPIO as GPIO
+import time
+
+GPIO.setmode(GPIO.BCM)
+GPIO.setup(18, GPIO.OUT)
+
+pwm = GPIO.PWM(18, 50)  # 50 Hz
+pwm.start(0)
+
+try:
+    while True:
+        for angle in range(0, 181, 30):
+            duty = 2.5 + angle / 18.0
+            pwm.ChangeDutyCycle(duty)
+            time.sleep(0.5)
+finally:
+    pwm.stop()
+    GPIO.cleanup()
+```
+
+更多脚本与示例可在 [pi5-mg90s-tools](https://github.com/SwartzMss/pi5-mg90s-tools) 仓库获取。
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
   - 脚本系统服务: service.md
   - 蜂鸣器: buzzer.md
   - 电机基础: motors.md
+  - MG90S 舵机: servo.md
   - nRF24L01 无线模块: nrf24l01.md
   - SH1106 OLED 屏幕: oled.md
   - MQTT 服务器: mqtt.md


### PR DESCRIPTION
## Summary
- document MG90S servo wiring and example code
- list servo article in index
- add servo page to mkdocs navigation

## Testing
- `make docs` *(fails: mkdocs missing)*

------
https://chatgpt.com/codex/tasks/task_e_6881dff7c76c8331a730f63366b2eaee