### PR TITLE
Add IR38K infrared receiver notes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@
 - [nRF24L01 无线模块](./nrf24l01.md)
 - [电机基础](./motors.md)
 - [MG90S 舵机](./servo.md)
+- [IR38K 红外接收](./irremote.md)
 - [蜂鸣器使用](./buzzer.md)
 - [USB 外置声卡](./usb-soundcard.md)
 - 硬件监控命令

--- a/docs/irremote.md
+++ b/docs/irremote.md
@@ -1,0 +1,23 @@
+# IR38K 红外接收模块
+
+IR38K 是常见的 38kHz 红外接收头，可用于读取各种遥控器的红外信号。本节介绍在树莓派 5 上连接该模块并配合 `pi5-ir38k-tools` 仓库解析按键代码的基本方法。
+
+## 硬件连接
+
+- VCC 接 3.3V
+- GND 接 GND
+- OUT 接 GPIO18（或任意可用 GPIO）
+
+## 示例脚本
+
+`pi5-ir38k-tools` 仓库提供了基于 `lgpio` 的示例脚本。克隆仓库后运行 `main.py` 即可在终端显示接收到的按键码：
+
+```bash
+git clone https://github.com/SwartzMss/pi5-ir38k-tools
+cd pi5-ir38k-tools
+python3 main.py --pin 18
+```
+
+脚本会持续输出检测到的十六进制编码，可据此编写自定义控制逻辑。
+
+更多脚本与说明可参考外部仓库 [pi5-ir38k-tools](https://github.com/SwartzMss/pi5-ir38k-tools)。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
   - 蜂鸣器: buzzer.md
   - 电机基础: motors.md
   - MG90S 舵机: servo.md
+  - IR38K 红外接收: irremote.md
   - nRF24L01 无线模块: nrf24l01.md
   - SH1106 OLED 屏幕: oled.md
   - MQTT 服务器: mqtt.md


### PR DESCRIPTION
## Summary
- document IR38K infrared receiver usage and link to external repo
- list the new page in navigation and index

## Testing
- `make docs` *(fails: mkdocs not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6881fa0dece48331a59e7bdc2dd41d6e