### PR TITLE
Add PS2 joystick docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@
 - [nRF24L01 无线模块](./nrf24l01.md)
 - [电机基础](./motors.md)
 - [MG90S 舵机](./servo.md)
-- [PS2 手柄工具](./ps2-joystick.md)
+- [PS2 摇杆/手柄](./ps2-joystick.md)
 - [IR38K 红外接收](./irremote.md)
 - [蜂鸣器使用](./buzzer.md)
 - [USB 外置声卡](./usb-soundcard.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@
 - [nRF24L01 无线模块](./nrf24l01.md)
 - [电机基础](./motors.md)
 - [MG90S 舵机](./servo.md)
+- [PS2 手柄工具](./ps2-joystick.md)
 - [IR38K 红外接收](./irremote.md)
 - [蜂鸣器使用](./buzzer.md)
 - [USB 外置声卡](./usb-soundcard.md)

--- a/docs/ps2-joystick.md
+++ b/docs/ps2-joystick.md
@@ -1,11 +1,42 @@
-# PS2 手柄连接与测试
+# PS2 摇杆与手柄模块
 
-使用 PlayStation 2 手柄可以在树莓派上实现游戏控制或简单的机器人遥控。
-本项目推荐使用 [`pi5-ps2-joystick-tools`](https://github.com/SwartzMss/pi5-ps2-joystick-tools) 仓库中的脚本进行调试。
+市面上常见的 "PS2 摇杆" 模块往往只有 `VRx` 与 `VRy` 两个模拟输出脚，
+无需任何数字通信即可读取摇杆位置。本节先介绍这种简单模块的接线与读取方式，
+随后补充带完整手柄接口的用法。
 
-## 接线方式
+## 仅带 VRx/VRy 的摇杆
 
-PS2 手柄转接板通常提供以下引脚：
+这些模块通常只引出四根线：`VCC`、`GND`、`VRx` 和 `VRy`。
+可利用外置 ADC（如 ADS1115）读取其两个模拟量。
+
+### 接线示例
+
+| 模块引脚 | 功能      | 连接                |
+|---------|---------|-------------------|
+| VCC     | 3.3V    | Pin 1             |
+| GND     | 地      | Pin 6             |
+| VRx     | X 轴电位 | ADS1115 A0 (P0)  |
+| VRy     | Y 轴电位 | ADS1115 A1 (P1)  |
+
+```python
+import board
+import busio
+from adafruit_ads1x15.ads1115 import ADS1115
+from adafruit_ads1x15.analog_in import AnalogIn
+
+i2c = busio.I2C(board.SCL, board.SDA)
+ads = ADS1115(i2c)
+x = AnalogIn(ads, ADS1115.P0)
+y = AnalogIn(ads, ADS1115.P1)
+print(x.value, y.value)
+```
+
+## 带 ATT/CLK/CMD/DAT 的手柄
+
+部分转接板会额外提供 `ATT`、`CLK`、`CMD`、`DAT` 等引脚，
+适用于连接完整的 PlayStation 2 手柄。
+推荐参考 [`pi5-ps2-joystick-tools`](https://github.com/SwartzMss/pi5-ps2-joystick-tools)
+仓库中的脚本进行调试，典型接线如下表所示：
 
 | 手柄引脚 | 功能             | 树莓派引脚示例 |
 |---------|----------------|-------------|
@@ -16,39 +47,18 @@ PS2 手柄转接板通常提供以下引脚：
 | CMD     | 命令           | GPIO10 (MOSI) |
 | DAT     | 数据           | GPIO9 (MISO) |
 
-此外，部分转接板还会引出模拟摇杆的 `VRx` 和 `VRy` 两个尖脚，
-若需要读取摇杆的电位，可将它们接到外置 ADC（如 ADS1115）：
-
-```
-VRx -> ADS1115 A0 (P0)
-VRy -> ADS1115 A1 (P1)
-```
-
-随后即可利用 `adafruit-circuitpython-ads1x15` 等库在 Python 中获取摇杆的电压数值。
-
-> 各转接板可能标注 `CS`、`SEL` 等不同名称，可按说明书接线。
-
-## 安装脚本
-
-脚本仓库提供读取手柄数据的 Python 示例：
+安装脚本：
 
 ```bash
-# 克隆仓库（需能访问 GitHub）
 # git clone https://github.com/SwartzMss/pi5-ps2-joystick-tools
 cd pi5-ps2-joystick-tools
 pip install -r requirements.txt
 ```
 
-安装完成后可运行 `python read_ps2.py` 查看按键状态。
-
-## 示例输出
-
-运行脚本后，终端会持续打印按钮与摇杆的数值，例如：
+执行 `python read_ps2.py` 后即可查看按键与摇杆状态。示例输出：
 
 ```
 LX: 127  LY: 128  RX: 127  RY: 128  Buttons: 0x0000
 ```
 
-各位值分别表示左右摇杆的 X/Y 位置与按键位掩码。
-
-更多用法与进阶示例，请访问上游仓库查看文档。
+关于更多用法，请查阅上游仓库的文档。

--- a/docs/ps2-joystick.md
+++ b/docs/ps2-joystick.md
@@ -16,6 +16,16 @@ PS2 手柄转接板通常提供以下引脚：
 | CMD     | 命令           | GPIO10 (MOSI) |
 | DAT     | 数据           | GPIO9 (MISO) |
 
+此外，部分转接板还会引出模拟摇杆的 `VRx` 和 `VRy` 两个尖脚，
+若需要读取摇杆的电位，可将它们接到外置 ADC（如 ADS1115）：
+
+```
+VRx -> ADS1115 A0 (P0)
+VRy -> ADS1115 A1 (P1)
+```
+
+随后即可利用 `adafruit-circuitpython-ads1x15` 等库在 Python 中获取摇杆的电压数值。
+
 > 各转接板可能标注 `CS`、`SEL` 等不同名称，可按说明书接线。
 
 ## 安装脚本

--- a/docs/ps2-joystick.md
+++ b/docs/ps2-joystick.md
@@ -1,0 +1,44 @@
+# PS2 手柄连接与测试
+
+使用 PlayStation 2 手柄可以在树莓派上实现游戏控制或简单的机器人遥控。
+本项目推荐使用 [`pi5-ps2-joystick-tools`](https://github.com/SwartzMss/pi5-ps2-joystick-tools) 仓库中的脚本进行调试。
+
+## 接线方式
+
+PS2 手柄转接板通常提供以下引脚：
+
+| 手柄引脚 | 功能             | 树莓派引脚示例 |
+|---------|----------------|-------------|
+| VCC     | 3.3V 供电       | Pin 1       |
+| GND     | 地             | Pin 6       |
+| ATT     | 片选/ATTENTION | GPIO8 (CE0) |
+| CLK     | 时钟           | GPIO11 (SCLK) |
+| CMD     | 命令           | GPIO10 (MOSI) |
+| DAT     | 数据           | GPIO9 (MISO) |
+
+> 各转接板可能标注 `CS`、`SEL` 等不同名称，可按说明书接线。
+
+## 安装脚本
+
+脚本仓库提供读取手柄数据的 Python 示例：
+
+```bash
+# 克隆仓库（需能访问 GitHub）
+# git clone https://github.com/SwartzMss/pi5-ps2-joystick-tools
+cd pi5-ps2-joystick-tools
+pip install -r requirements.txt
+```
+
+安装完成后可运行 `python read_ps2.py` 查看按键状态。
+
+## 示例输出
+
+运行脚本后，终端会持续打印按钮与摇杆的数值，例如：
+
+```
+LX: 127  LY: 128  RX: 127  RY: 128  Buttons: 0x0000
+```
+
+各位值分别表示左右摇杆的 X/Y 位置与按键位掩码。
+
+更多用法与进阶示例，请访问上游仓库查看文档。

--- a/docs/ps2-joystick.md
+++ b/docs/ps2-joystick.md
@@ -54,11 +54,6 @@ print(x.value, y.value)
 cd pi5-ps2-joystick-tools
 pip install -r requirements.txt
 ```
-
-执行 `python read_ps2.py` 后即可查看按键与摇杆状态。示例输出：
-
-```
-LX: 127  LY: 128  RX: 127  RY: 128  Buttons: 0x0000
-```
+执行 `python read_ps2.py` 后即可查看按键与摇杆状态。
 
 关于更多用法，请查阅上游仓库的文档。

--- a/docs/ps2-joystick.md
+++ b/docs/ps2-joystick.md
@@ -31,29 +31,3 @@ y = AnalogIn(ads, ADS1115.P1)
 print(x.value, y.value)
 ```
 
-## 带 ATT/CLK/CMD/DAT 的手柄
-
-部分转接板会额外提供 `ATT`、`CLK`、`CMD`、`DAT` 等引脚，
-适用于连接完整的 PlayStation 2 手柄。
-推荐参考 [`pi5-ps2-joystick-tools`](https://github.com/SwartzMss/pi5-ps2-joystick-tools)
-仓库中的脚本进行调试，典型接线如下表所示：
-
-| 手柄引脚 | 功能             | 树莓派引脚示例 |
-|---------|----------------|-------------|
-| VCC     | 3.3V 供电       | Pin 1       |
-| GND     | 地             | Pin 6       |
-| ATT     | 片选/ATTENTION | GPIO8 (CE0) |
-| CLK     | 时钟           | GPIO11 (SCLK) |
-| CMD     | 命令           | GPIO10 (MOSI) |
-| DAT     | 数据           | GPIO9 (MISO) |
-
-安装脚本：
-
-```bash
-# git clone https://github.com/SwartzMss/pi5-ps2-joystick-tools
-cd pi5-ps2-joystick-tools
-pip install -r requirements.txt
-```
-执行 `python read_ps2.py` 后即可查看按键与摇杆状态。
-
-关于更多用法，请查阅上游仓库的文档。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,7 +22,7 @@ nav:
   - 蜂鸣器: buzzer.md
   - 电机基础: motors.md
   - MG90S 舵机: servo.md
-  - PS2 手柄工具: ps2-joystick.md
+  - PS2 摇杆/手柄: ps2-joystick.md
   - IR38K 红外接收: irremote.md
   - nRF24L01 无线模块: nrf24l01.md
   - SH1106 OLED 屏幕: oled.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
   - 蜂鸣器: buzzer.md
   - 电机基础: motors.md
   - MG90S 舵机: servo.md
+  - PS2 手柄工具: ps2-joystick.md
   - IR38K 红外接收: irremote.md
   - nRF24L01 无线模块: nrf24l01.md
   - SH1106 OLED 屏幕: oled.md


### PR DESCRIPTION
## Summary
- document how to use a PS2 controller
- link to example repository `pi5-ps2-joystick-tools`
- add the new page to navigation and index

## Testing
- `make docs` *(fails: mkdocs missing)*

------
https://chatgpt.com/codex/tasks/task_e_6885fde2e09c833188df7d70209e66b8