### PR TITLE
Add Node-RED MQTT example

### DIFF
--- a/docs/webserver.md
+++ b/docs/webserver.md
@@ -24,14 +24,10 @@ node-red
 
 ## 构建 HTTP 端口
 
-1. 打开编辑界面，拖拽“Inject”、“Function”和“HTTP response”节点到流程中。
-2. 将“Inject”节点设置为“GET /hello”，并连接到“Function”。
-3. 在“Function”节点中填写：
-   ```javascript
-   msg.payload = 'Hello from Node-RED';
-   return msg;
-   ```
-4. 最后连接到“HTTP response”节点，并点击上方的“Deploy”完成部署。
+1. 在编辑界面依次拖入 **HTTP in**、**template** 和 **HTTP response** 节点。
+2. 将 **HTTP in** 节点配置为 `GET /hello` 并连接到 **template**。
+3. 双击 **template** 节点，在文本框中直接填入 `Hello from Node-RED`。
+4. 将其连接到 **HTTP response** 节点后点击 **Deploy** 完成部署。
 
 现在访问 `http://<本地IP>:1880/hello` 就会返回“Hello from Node-RED”。
 
@@ -45,3 +41,31 @@ sudo systemctl enable nodered.service
 
 更多信息请查阅官方文档，或直接查看编辑界面工具提供的实用帮助。
 
+
+## 结合 MQTT 显示温湿度
+
+除了构建 HTTP API，Node-RED 还可以通过 MQTT 处理传感器数据。以下示例展示如何将 DHT22 温湿度读数发布到 MQTT，并在 Dashboard 中绘制曲线。
+
+1. 按照 [MQTT 服务器](./mqtt.md) 的说明安装并启动 Mosquitto。
+2. 使用 `Adafruit_DHT` 与 `paho-mqtt` 编写脚本，定期发布 JSON 数据：
+   ```python
+   import json
+   import time
+   import Adafruit_DHT
+   import paho.mqtt.publish as publish
+
+   sensor = Adafruit_DHT.DHT22
+   pin = 4
+
+   while True:
+       h, t = Adafruit_DHT.read_retry(sensor, pin)
+       if h is not None and t is not None:
+           data = json.dumps({"temperature": t, "humidity": h})
+           publish.single("sensors/dht22", data, hostname="localhost")
+       time.sleep(5)
+   ```
+3. 在 Node-RED 中安装 `node-red-dashboard`，并按照下列方式拖拽节点：
+   - **mqtt in** 节点订阅 `sensors/dht22`，连接到 **json** 节点；
+   - 使用两个 **change** 节点分别提取 `msg.payload.temperature` 和 `msg.payload.humidity`；
+   - 将它们各自连到对应的 **chart** 节点。
+4. 点击 **Deploy** 后访问 `http://<本地IP>:1880/ui` 即可查看实时曲线。


### PR DESCRIPTION
## Summary
- extend webserver doc with steps to publish DHT22 sensor data via MQTT
- show how to subscribe in Node-RED and draw charts
- clarify HTTP endpoint setup with drag-and-drop nodes only

## Testing
- `make docs` *(fails: mkdocs not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688c2142c6ec8331af216859c0ae393d